### PR TITLE
props: remove camera privapp whitelist

### DIFF
--- a/vendor_prop.mk
+++ b/vendor_prop.mk
@@ -135,12 +135,11 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # Camera
 PRODUCT_PROPERTY_OVERRIDES += \
-    persist.vendor.camera.privapp.list=com.oneplus.camera,org.lineageos.snap,com.google.android.GoogleCamera \
     persist.camera.mobicat=2 \
     persist.camera.stats.debugexif=3080192 \
     persist.ts.rtmakeup=false \
     persist.vendor.camera.tintless.skip=1 \
-	vendor.camera.aux.packagelist=org.codeaurora.snapcam,com.oneplus.camera,com.google.android.GoogleCamera
+    vendor.camera.aux.packagelist=org.codeaurora.snapcam,com.oneplus.camera,com.google.android.GoogleCamera
 
 # Codec2 switch
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
this breaks main cam on few gcams and adding this doesn't do any good anyways 
so might as well remove 'em